### PR TITLE
Improvement/new-api-ids-to-objects

### DIFF
--- a/src/Files.svelte
+++ b/src/Files.svelte
@@ -104,7 +104,6 @@
           "uploadDate",
           "modifyDate",
           "rating",
-          "userID",
           "fileSize",
           "dominantColor",
           "subject",

--- a/src/main.js
+++ b/src/main.js
@@ -216,7 +216,6 @@ class PIXXIO {
 							"uploadDate",
 							"modifyDate",
 							"rating",
-							"userID",
 							"fileSize",
 							"dominantColor",
 							"versions"


### PR DESCRIPTION
removed userID from responseFields as this data is not needed ( + "userID" as responseField is deprecated)